### PR TITLE
Allow to specify filenames according to requests lib format

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -40,7 +40,7 @@ class ActionShortcut(object):
         def action(**kwargs):
             files = {}
             for k, v in kwargs.items():
-                if hasattr(v, 'read'):
+                if hasattr(v, 'read') or (isinstance(v, (list, tuple)) and len(v) >= 2 and hasattr(v[1], 'read')):
                     files[k] = v
             if files:
                 nonfiles = dict((k, v) for k, v in kwargs.items()


### PR DESCRIPTION
Allow to specify tuple `('filename.xls', open('filename.xls'))` for 'upload' or any other field: specify filename according to requests lib format (see http://docs.python-requests.org/en/latest/user/quickstart/#more-complicated-post-requests)

Right now using `upload: open('filename.xls')` ckan won't receive the filename which will result in dummy 'upload' file, ie. http://localhost:5000/dataset/1b469259-02e2-43fa-864a-bf018eeef059/resource/799fb449-6249-4ea6-8ddd-24550b5b8dba/download/upload

ref #45
